### PR TITLE
Descendant and ancestor iterator optimizations

### DIFF
--- a/lde/src/experimental/manytest.js
+++ b/lde/src/experimental/manytest.js
@@ -1,0 +1,47 @@
+////////////////////////////////////////////////////////////////////////////
+// Script to run the Lode .test suite from the command line with
+// 
+// node lode test
+//
+// from the command line for profiling.
+//
+////////////////////////////////////////////////////////////////////////////
+
+let times = []
+
+LurchOptions.runStudentTests = false
+initialize('utils/acidtests')
+times.push(globalThis.runtimeMS)
+initialize('utils/acidtests')
+times.push(globalThis.runtimeMS)
+initialize('utils/acidtests')
+times.push(globalThis.runtimeMS)
+initialize('utils/acidtests')
+times.push(globalThis.runtimeMS)
+initialize('utils/acidtests')
+times.push(globalThis.runtimeMS)
+initialize('utils/acidtests')
+times.push(globalThis.runtimeMS)
+initialize('utils/acidtests')
+times.push(globalThis.runtimeMS)
+initialize('utils/acidtests')
+times.push(globalThis.runtimeMS)
+initialize('utils/acidtests')
+times.push(globalThis.runtimeMS)
+initialize('utils/acidtests')
+times.push(globalThis.runtimeMS)
+
+times.sort()
+times = times.slice(1, -1)
+
+console.log(times)
+
+let avg = Math.round(times.reduce( (sum, val) => sum + val, 0) / times.length)
+
+console.log(avg)
+
+process.exit()
+
+// don't echo anything
+undefined
+///////////////////////////////////////////////////////////

--- a/lde/src/experimental/utils/acidtests.js
+++ b/lde/src/experimental/utils/acidtests.js
@@ -197,7 +197,8 @@ console.log(`Test result stored in the array 'acid'\n`)
 
 ///////////////////////////////////////////////////////////
 // closing
-console.log(defaultPen(`done! (${msToTime(Date.now()-start)})`))
+runtimeMS = Date.now()-start
+console.log(defaultPen(`done! (${msToTime(runtimeMS)})`))
 // don't echo anything
 undefined
 ///////////////////////////////////////////////////////////

--- a/lde/src/math-concept.js
+++ b/lde/src/math-concept.js
@@ -685,9 +685,21 @@ export class MathConcept extends Superclass {
      * @see {@link MathConcept#hasDescendantSatisfying hasDescendantSatisfying()}
      */
     *descendantsIterator () {
+    // *descendantsIteratorStack () {
+        let stack = [ this ]
+        while (stack.length > 0) {
+            let curr = stack.pop()
+            yield curr
+            stack.push(...curr._children)
+        }
+    }
+
+    // *descendantsIterator () {
+    *descendantsIteratorRecursive () {
         yield this
         for ( let child of this._children ) yield* child.descendantsIterator()
     }
+
 
     /**
      * An array of those descendants of this MathConcept that satisfy the given
@@ -714,6 +726,18 @@ export class MathConcept extends Superclass {
         return result
     }
 
+    // Not helpful yet
+    descendantsSatisfyingInline ( predicate ) {
+        let result = [ ]
+        let stack = [ this ]
+        while (stack.length > 0) {
+            let curr = stack.pop()
+            if ( predicate( curr ) ) result.push( curr )
+            stack.push(...curr._children)
+        }
+        return result
+    }
+
     /**
      * Whether this MathConcept has any descendant satisfying the given predicate.
      * The predicate will be evaluated on each descendant in depth-first order
@@ -737,6 +761,18 @@ export class MathConcept extends Superclass {
         return false
     }
 
+    // Not helpful on small tests
+    hasDescendantSatisfyingInline ( predicate ) {
+        let stack = [ this ]
+        while (stack.length > 0) {
+            let curr = stack.pop()
+            if ( predicate( curr ) ) return true
+            stack.push(...curr._children)
+        }
+        return false
+    }
+
+
     /**
      * An iterator through all the ancestors of this MathConcept, starting with
      * itself as the first (trivial) ancestor, and walking upwards from there.
@@ -748,6 +784,16 @@ export class MathConcept extends Superclass {
      * @see {@link MathConcept#parent parent()}
      */
     *ancestorsIterator () {
+    // *ancestorsIteratorIterative () {
+        let curr = this
+        do {
+            yield curr
+            curr = curr._parent
+        } while ( curr )
+    }
+
+    // *ancestorsIterator () {
+    *ancestorsIteratorRecursive () {
         yield this
         if ( this.parent() ) yield* this.parent().ancestorsIterator()
     }

--- a/lde/src/math-concept.js
+++ b/lde/src/math-concept.js
@@ -831,6 +831,17 @@ export class MathConcept extends Superclass {
         return result
     }
 
+    // Not useful yet
+    ancestorsSatisfyingInline ( predicate ) {
+        const result = [ ]
+        let curr = this
+        do {
+            if ( predicate( curr ) ) result.push( curr )
+            curr = curr._parent
+        } while ( curr )
+        return result
+    }
+
     /**
      * Whether this MathConcept has an ancestor (including itself) satisfying the
      * given predicate.
@@ -846,6 +857,16 @@ export class MathConcept extends Superclass {
     hasAncestorSatisfying ( predicate ) {
         for ( let ancestor of this.ancestorsIterator() )
             if ( predicate( ancestor ) ) return true
+        return false
+    }
+
+    // Not useful yet
+    hasAncestorSatisfyingInline ( predicate ) {
+        let curr = this
+        do {
+            if ( predicate( curr ) ) return true
+            curr = curr._parent
+        } while ( curr )
         return false
     }
 


### PR DESCRIPTION
Swapped out the recursive definitions of `descendantIterator` and `ancestorIterator` for iterative ones.  Added a little extra code for more robust performance comparisons.